### PR TITLE
Graph filename bash arg

### DIFF
--- a/bin/gather_paths_by_config.sh
+++ b/bin/gather_paths_by_config.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# This script gathers the paths to the .dat files with the given
+# configuration name.
+#
+# If multiple runs were performed in a SINGLE process, the .dat file
+# has "run" prefixing the actual run index. For example:
+#
+#       best_scores_run5_Catcher_sa_no_opt_data.dat
+#
+# else the .dat file's name should not contain the prefix and the 
+# name of game comes before the run index. For instance:
+#
+#       best_scores_Catcher_5_sa_no_opt_data.dat
+#
+# This is to differentiate searches done in different processes/jobs from those
+# those done in a single process/job.
+#
+
+config=$1
+total_runs=$2
+game=$3
+was_single_process=$4
+paths_file=${config}_paths
+touch $paths_file
+
+rm ${paths_file}
+
+for ((i=0; i < $total_runs; i++)) {
+    if [ -z "$was_single_process" ]
+        then
+            echo "best_scores_${game}_${i}_${config}_data.dat" >> ${paths_file}
+        else
+            echo "best_scores_run${i}_${game}__${config}_data.dat" >> ${paths_file}
+    fi
+}

--- a/bin/sa_no_opt.sh
+++ b/bin/sa_no_opt.sh
@@ -17,20 +17,43 @@
 # Log filename: log_[game]_sa_no_optimizer-[date & time]
 # 
 # Total games: ${total_games}
+config="sa_no_optimizer"
 
 game=$1
 time=$2
 total_games=$3
+multi_run=$4
+same_process=$5
+run_index=$6
 
-if [ -z "$multi_run" ]
+if [ "$multi_run" = "1" ]
     then
         mr=""
+        run_index=""
     else
-        mr="-mr ${multi_run}"
+        if [ "$same_process" = "same" ]
+            then
+                mr="-mr ${multi_run}"   # same process will run SA multiple times
+                run_index=""            # user doesn't need to specify a run index
+            else
+                mr=""
+                if [ -z "$run_index" ]
+                    then
+                        run_index=1     # user needs a run index, default value is 1
+                fi
+
+                echo "run index: $run_index"
+        fi
 fi
 
-python -m src.main -t ${time} -l log_${game}_sa_no_optimizer \
+log_name=log_${run_index}_${game}_${config}
+plot_name=${game}_${run_index}_${config}_graph
+
+echo "log file: ${log_name}"
+echo "plot name: ${plot_name}"
+
+python -m src.main -t ${time} -l ${log_name} \
     -g ${game} -s SimulatedAnnealing --tg ${total_games} \
-    --plot --plot-name sa_no_optimizer_graph --save \
+    --plot --plot-name ${plot_name} --save ${config} \
     ${mr} \
     --no-warn

--- a/bin/sa_no_opt_triage_eval.sh
+++ b/bin/sa_no_opt_triage_eval.sh
@@ -17,21 +17,43 @@
 # Log filename: log_[game]_sa_no_opt_triage_eval-[date & time]
 # 
 # Total games: ${total_games}
+config="sa_no_opt_triage_eval"
 
 game=$1
 time=$2
 total_games=$3
 multi_run=$4
+same_process=$5
+run_index=$6
 
-if [ -z "$multi_run" ]
+if [ "$multi_run" = "1" ]
     then
         mr=""
+        run_index=""
     else
-        mr="-mr ${multi_run}"
+        if [ "$same_process" = "same" ]
+            then
+                mr="-mr ${multi_run}"   # same process will run SA multiple times
+                run_index=""            # user doesn't need to specify a run index
+            else
+                mr=""
+                if [ -z "$run_index" ]
+                    then
+                        run_index=1     # user needs a run index, default value is 1
+                fi
+
+                echo "run index: $run_index"
+        fi
 fi
 
-python -u -m src.main -t ${time} -l log_${game}_sa_no_opt_triage_eval \
+log_name=log_${run_index}_${game}_${config}
+plot_name=${game}_${run_index}_${config}_graph
+
+echo "log file: ${log_name}"
+echo "plot name: ${plot_name}"
+
+python -u -m src.main -t ${time} -l ${log_name} \
     -g ${game} -s SimulatedAnnealing --tg ${total_games} --te \
-    --plot --plot-name sa_no_opt_triage_eval_graph --save \
+    --plot --plot-name ${plot_name} --save --config ${config} \
     ${mr} \
     --no-warn

--- a/bin/sa_non_triage_opt.sh
+++ b/bin/sa_non_triage_opt.sh
@@ -17,21 +17,44 @@
 # Log filename: log_[game]_sa_non_triage_opt-[date & time]
 # 
 # Total games: ${total_games}
+config="sa_non_triage_opt"
 
 game=$1
 time=$2
 total_games=$3
+multi_run=$4
+same_process=$5
+run_index=$6
 
-if [ -z "$multi_run" ]
+if [ "$multi_run" = "1" ]
     then
         mr=""
+        run_index=""
     else
-        mr="-mr ${multi_run}"
+        if [ "$same_process" = "same" ]
+            then
+                mr="-mr ${multi_run}"   # same process will run SA multiple times
+                run_index=""            # user doesn't need to specify a run index
+            else
+                mr=""
+                if [ -z "$run_index" ]
+                    then
+                        run_index=1     # user needs a run index, default value is 1
+                fi
+
+                echo "run index: $run_index"
+        fi
 fi
 
-python -m src.main -t ${time} -l log_${game}_sa_non_triage_opt \
+log_name=log_${run_index}_${game}_${config}
+plot_name=${game}_${run_index}_${config}_graph
+
+echo "log file: ${log_name}"
+echo "plot name: ${plot_name}"
+
+python -m src.main -t ${time} -l ${log_name} \
     -o \
     -g ${game} -s SimulatedAnnealing --tg ${total_games} \
-    --plot --plot-name sa_non_triage_opt_graph --save \
+    --plot --plot-name ${plot_name} --save ${config} \
     ${mr} \
     --no-warn

--- a/bin/sa_non_triage_opt_triage_eval.sh
+++ b/bin/sa_non_triage_opt_triage_eval.sh
@@ -17,21 +17,44 @@
 # Log filename: log_[game]_sa_non_triage_opt_triage_eval-[date & time]
 # 
 # Total games: ${total_games}
+config="sa_non_triage_opt_triage_eval"
 
 game=$1
 time=$2
 total_games=$3
+multi_run=$4
+same_process=$5
+run_index=$6
 
-if [ -z "$multi_run" ]
+if [ "$multi_run" = "1" ]
     then
         mr=""
+        run_index=""
     else
-        mr="-mr ${multi_run}"
+        if [ "$same_process" = "same" ]
+            then
+                mr="-mr ${multi_run}"   # same process will run SA multiple times
+                run_index=""            # user doesn't need to specify a run index
+            else
+                mr=""
+                if [ -z "$run_index" ]
+                    then
+                        run_index=1     # user needs a run index, default value is 1
+                fi
+
+                echo "run index: $run_index"
+        fi
 fi
 
-python -m src.main -t ${time} -l log_${game}_sa_non_triage_opt_triage_eval \
+log_name=log_${run_index}_${game}_${config}
+plot_name=${game}_${run_index}_${config}_graph
+
+echo "log file: ${log_name}"
+echo "plot name: ${plot_name}"
+
+python -m src.main -t ${time} -l ${log_name} \
     -o \
     -g ${game} -s SimulatedAnnealing --tg ${total_games} --te \
-    --plot --plot-name sa_non_triage_opt_triage_eval_graph --save \
+    --plot --plot-name ${plot_name} --save ${config} \
     ${mr} \
     --no-warn

--- a/bin/sa_triage_opt.sh
+++ b/bin/sa_triage_opt.sh
@@ -17,21 +17,44 @@
 # Log filename: log_[game]_sa_triage_opt-[date & time]
 # 
 # Total games: ${total_games}
+config="sa_triage_opt"
 
 game=$1
 time=$2
 total_games=$3
+multi_run=$4
+same_process=$5
+run_index=$6
 
-if [ -z "$multi_run" ]
+if [ "$multi_run" = "1" ]
     then
         mr=""
+        run_index=""
     else
-        mr="-mr ${multi_run}"
+        if [ "$same_process" = "same" ]
+            then
+                mr="-mr ${multi_run}"   # same process will run SA multiple times
+                run_index=""            # user doesn't need to specify a run index
+            else
+                mr=""
+                if [ -z "$run_index" ]
+                    then
+                        run_index=1     # user needs a run index, default value is 1
+                fi
+
+                echo "run index: $run_index"
+        fi
 fi
 
-python -m src.main -t ${time} -l log_${game}_sa_triage_opt \
+log_name=log_${run_index}_${game}_${config}
+plot_name=${game}_${run_index}_${config}_graph
+
+echo "log file: ${log_name}"
+echo "plot name: ${plot_name}"
+
+python -m src.main -t ${time} -l ${log_name} \
     -o --optimizer-triage \
     -g ${game} -s SimulatedAnnealing --tg ${total_games} \
-    --plot --plot-name sa_triage_opt_graph --save \
+    --plot --plot-name ${plot_name} --save ${config} \
     ${mr} \
     --no-warn

--- a/bin/sa_triage_opt_triage_eval.sh
+++ b/bin/sa_triage_opt_triage_eval.sh
@@ -17,21 +17,44 @@
 # Log filename: log_[game]_sa_triage_opt_triage_eval-[date & time]
 # 
 # Total games: ${total_games}
+config="sa_triage_opt_triage_eval"
 
 game=$1
 time=$2
 total_games=$3
+multi_run=$4
+same_process=$5
+run_index=$6
 
-if [ -z "$multi_run" ]
+if [ "$multi_run" = "1" ]
     then
         mr=""
+        run_index=""
     else
-        mr="-mr ${multi_run}"
+        if [ "$same_process" = "same" ]
+            then
+                mr="-mr ${multi_run}"   # same process will run SA multiple times
+                run_index=""            # user doesn't need to specify a run index
+            else
+                mr=""
+                if [ -z "$run_index" ]
+                    then
+                        run_index=1     # user needs a run index, default value is 1
+                fi
+
+                echo "run index: $run_index"
+        fi
 fi
 
-python -m src.main -t ${time} -l log_${game}_sa_triage_opt_triage_eval \
+log_name=log_${run_index}_${game}_${config}
+plot_name=${game}_${run_index}_${config}_graph
+
+echo "log file: ${log_name}"
+echo "plot name: ${plot_name}"
+
+python -m src.main -t ${time} -l ${log_name} \
     -o --optimizer-triage \
     -g ${game} -s SimulatedAnnealing --tg ${total_games} --te \
-    --plot --plot-name sa_triage_opt_triage_eval_graph --save \
+    --plot --plot-name ${plot_name} --save ${config} \
     ${mr} \
     --no-warn


### PR DESCRIPTION
- Modify bash scripts intended to launch the synthesizer, so that they can accept a multi-run argument.
- The user can specify whether the synthesizer should be run multiple times and if so, within the same process or across different processes.
- Add gather_paths_by_config.sh which gathers the paths to the .dat files in data/ that store the best scores of previous runs of the synthesizer. Those previous runs must have a specific name format, which is automatically produced by the other scripts when launching the synthesizer with the multi-run argument, either within the same process or across different processes.
    - For instance, a .dat file storing the best scores of the third run, out of 10 runs, of a synthesizer without any optimizer and launched through the bash scripts described above will have the name **best_scores_run2_Catcher__sa_no_opt_data.dat** if all runs were within a single process and name **best_scores_Catcher_2_sa_no_opt_data.dat** if the run was in its own process.